### PR TITLE
タスク管理追加（曜日指定・days_mask対応）

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Database
 ```bash
 psql "$DATABASE_URL" -f migrations/001_create_users.sql
 psql "$DATABASE_URL" -f migrations/002_create_children.sql
+psql "$DATABASE_URL" -f migrations/003_create_tasks.sql
 ```
 
 ### curl例（login → token → children）
@@ -120,5 +121,29 @@ curl -s -X POST http://localhost:3000/api/v1/children \\
 
 # list children
 curl -s -X GET http://localhost:3000/api/v1/children \\
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### curl例（task 作成 → 一覧 → 更新）
+
+```bash
+# create task
+curl -s -X POST http://localhost:3000/api/v1/children/$CHILD_ID/tasks \\
+  -H "Authorization: Bearer $TOKEN" \\
+  -H "Content-Type: application/json" \\
+  -d '{"name":"Math Drill","subject":"math","default_minutes":20,"days_mask":62}'
+
+# list tasks (archived=false default)
+curl -s -X GET "http://localhost:3000/api/v1/children/$CHILD_ID/tasks" \\
+  -H "Authorization: Bearer $TOKEN"
+
+# update task (archive)
+curl -s -X PATCH http://localhost:3000/api/v1/tasks/$TASK_ID \\
+  -H "Authorization: Bearer $TOKEN" \\
+  -H "Content-Type: application/json" \\
+  -d '{"is_archived":true}'
+
+# list archived tasks
+curl -s -X GET "http://localhost:3000/api/v1/children/$CHILD_ID/tasks?archived=true" \\
   -H "Authorization: Bearer $TOKEN"
 ```

--- a/migrations/003_create_tasks.sql
+++ b/migrations/003_create_tasks.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS tasks (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES users(id),
+  child_id uuid NOT NULL REFERENCES children(id),
+  name text NOT NULL,
+  description text NULL,
+  subject text NOT NULL,
+  default_minutes int NOT NULL DEFAULT 15,
+  days_mask int NOT NULL,
+  is_archived boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CHECK (default_minutes >= 1),
+  CHECK (days_mask BETWEEN 1 AND 127)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tasks_child_archived ON tasks(child_id, is_archived);
+CREATE INDEX IF NOT EXISTS idx_tasks_user_id ON tasks(user_id);


### PR DESCRIPTION
概要
	•	学習タスク管理機能を追加
	•	曜日指定を days_mask（bitmask）で管理
	•	子供（child）配下でのタスクCRUDを実装
	•	論理削除（is_archived）対応

DB変更
	•	tasks テーブル追加
	•	subject（必須）
	•	default_minutes（必須・default 15）
	•	days_mask（必須・1〜127）
	•	is_archived（論理削除）
	•	CHECK制約・インデックス追加

API追加
	•	POST /children/:childId/tasks
	•	GET /children/:childId/tasks?archived=
	•	PATCH /tasks/:taskId
	•	全API JWT認証必須
	•	child / task の所有権チェック実装（他ユーザーは404）

検証内容
	•	login → JWT取得
	•	子供作成
	•	タスク作成（days_mask=127）
	•	タスク一覧取得
	•	全て期待どおり動作を確認