### PR TITLE
学習時間サマリー集計API追加（週/月/期間指定）

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,3 +195,15 @@ curl -s -X GET "http://localhost:3000/api/v1/children/$CHILD_ID/calendar-summary
 - green: 完了 = 全タスク
 - yellow: 一部完了
 - red: 未完了
+
+### curl例（summary）
+
+```bash
+# 1週間
+curl -s -X GET "http://localhost:3000/api/v1/children/$CHILD_ID/summary?from=2026-01-01&to=2026-01-07" \\
+  -H "Authorization: Bearer $TOKEN"
+
+# 1ヶ月
+curl -s -X GET "http://localhost:3000/api/v1/children/$CHILD_ID/summary?from=2026-01-01&to=2026-01-31" \\
+  -H "Authorization: Bearer $TOKEN"
+```


### PR DESCRIPTION
# 概要
	•	振り返り（週/月/期間指定）画面用に、指定期間の学習時間サマリーを返すAPIを追加
	•	集計元は study_logs（チェック済みのみ保存）で軽量
	•	日別 / 科目別 / タスク別 の集計を返す

# 追加API（JWT必須）
	•	GET /api/v1/children/:childId/summary?from=YYYY-MM-DD&to=YYYY-MM-DD

# レスポンス
	•	total_minutes：期間合計
	•	by_day：日別合計（昇順）
	•	by_subject：科目別合計（降順）
	•	by_task：タスク別合計（降順、taskのname/subject含む）

# 集計対象
	•	study_logs の child_id かつ date が [from,to] の範囲
	•	task の name/subject は tasks を参照（JOIN）
	•	tasks が is_archived でも過去ログは集計に含める（実績として保持）

# アクセス制御
	•	JWT user_id を基準に child 所有権チェック
	•	他ユーザー child は 404（情報漏洩防止）

# バリデーション
	•	from/to 必須、形式不正は 400
	•	from > to は 400
	•	期間が長すぎる場合は 400（上限設定）

# 検証
	•	from=2026-01-20&to=2026-01-31 で 200 OK を確認
	•	study_logs が無い期間のため total_minutes=0 / 各配列空を確認（仕様どおり）