### PR TITLE
ローカルの Next.js フロントエンドから API を呼べるように

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,14 @@
       "license": "ISC",
       "dependencies": {
         "bcrypt": "^5.1.1",
+        "cors": "^2.8.6",
         "express": "^5.2.1",
         "jsonwebtoken": "^9.0.2",
         "pg": "^8.13.1"
       },
       "devDependencies": {
         "@types/bcrypt": "^5.0.2",
+        "@types/cors": "^2.8.19",
         "@types/express": "^5.0.6",
         "@types/jsonwebtoken": "^9.0.7",
         "@types/node": "^25.0.10",
@@ -153,6 +155,16 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -599,6 +611,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/create-require": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-          "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
-      	  "test": "echo \"Error: no test specified\" && exit 1"
+    "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],
   "author": "",
@@ -13,12 +13,14 @@
   "type": "commonjs",
   "dependencies": {
     "bcrypt": "^5.1.1",
+    "cors": "^2.8.6",
     "express": "^5.2.1",
     "jsonwebtoken": "^9.0.2",
     "pg": "^8.13.1"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",
+    "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
     "@types/jsonwebtoken": "^9.0.7",
     "@types/node": "^25.0.10",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,24 @@
 import bcrypt from "bcrypt";
+import cors from "cors";
 import express from "express";
 import jwt from "jsonwebtoken";
 import { pool } from "./db";
 
 const app = express();
+const allowedOrigins = new Set(["http://localhost:3001", "http://localhost:3000"]);
+const corsOptions: cors.CorsOptions = {
+  origin: (origin, callback) => {
+    if (!origin || allowedOrigins.has(origin)) {
+      return callback(null, true);
+    }
+    return callback(new Error("Not allowed by CORS"));
+  },
+  methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+  allowedHeaders: ["Content-Type", "Authorization"],
+  credentials: false,
+};
+
+app.use(cors(corsOptions));
 app.use(express.json());
 
 app.get("/health", (_req, res) => {


### PR DESCRIPTION
## 概要
ローカルの Next.js フロントエンド（http://localhost:3001）から API を呼べるように CORS を有効化しました。

## 背景
フロント（3001）→ API（3000）が別オリジンとなり、ブラウザで /auth/login などが CORS error になっていたため。

## 変更内容
- `cors` を導入し、許可 Origin を最小限に制限
  - `http://localhost:3001`
  - `http://localhost:3000`
- `Authorization` ヘッダを許可（JWT用）
- Origin が無いリクエスト（curl/Postman等）は許可
- CORS ミドルウェアを `express.json()` より前に配置

## 動作確認
- Next.js（http://localhost:3001）からログインできることを確認
- curl での API 呼び出しが引き続き可能なことを確認

## 備考
- Express 5 では `app.options("*", ...)` がエラーになるため使用しません（`app.use(cors(...))` で preflight 対応）