### PR TITLE
調査ログ追加

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import jwt from "jsonwebtoken";
 import { pool } from "./db";
 
 const app = express();
+console.log("CORS_ORIGINS=", process.env.CORS_ORIGINS);
 const envOrigins = (process.env.CORS_ORIGINS ?? "")
   .split(",")
   .map((value) => value.trim())
@@ -12,7 +13,11 @@ const envOrigins = (process.env.CORS_ORIGINS ?? "")
 const allowedOrigins = new Set(
   envOrigins.length > 0
     ? envOrigins
-    : ["http://localhost:3000", "http://localhost:3001"],
+    : [
+        "http://localhost:3000",
+        "http://localhost:3001",
+        "https://learning-app-web-tan.vercel.app",
+      ],
 ); // default to local dev when env is empty
 const corsOptions: cors.CorsOptions = {
   origin: (origin, callback) => {


### PR DESCRIPTION
## 背景 / 目的

Vercel にデプロイした learning-app-web から Render の ts-memo-api を呼ぶと、ログイン時に CORS で拒否されるため、
ブラウザ経由（Vercel）でも API を利用できる状態にする。

⸻

## 現象（調査ログ）
	•	Vercelのログイン画面からログイン実行 → 失敗
	•	Render 側ログで下記が発生：

```
Error: Not allowed by CORS
    at origin (.../dist/index.js:18:25)
    at .../node_modules/cors/lib/index.js:219:13

```    
## アクセス状況
	•	TalendAPI Tester / curl では成功（＝ブラウザの Origin 制約のみが原因）
	•	TalendAPI Tester：OK
	•	curl：OK
	•	Vercel（ブラウザ）：NG（CORS拒否）    
	