### PR TITLE
Google / GitHub の OAuth ログインを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,3 +207,32 @@ curl -s -X GET "http://localhost:3000/api/v1/children/$CHILD_ID/summary?from=202
 curl -s -X GET "http://localhost:3000/api/v1/children/$CHILD_ID/summary?from=2026-01-01&to=2026-01-31" \\
   -H "Authorization: Bearer $TOKEN"
 ```
+
+---
+
+## OAuth（Google/GitHub）
+
+### 環境変数
+
+- `FRONTEND_URL` (例: `http://localhost:3001`)
+- `OAUTH_REDIRECT_BASE_URL` (例: `http://localhost:3000`)
+- `GOOGLE_CLIENT_ID`
+- `GOOGLE_CLIENT_SECRET`
+- `GITHUB_CLIENT_ID`
+- `GITHUB_CLIENT_SECRET`
+
+### 動作確認
+
+1) 認証開始（ブラウザでアクセス）
+
+- `http://localhost:3000/api/v1/auth/oauth/google/start`
+- `http://localhost:3000/api/v1/auth/oauth/github/start`
+
+2) 認証後、`FRONTEND_URL/login/callback?token=...` にリダイレクトされること
+
+3) 受け取った token で API が使えること
+
+```bash
+curl -s -X GET http://localhost:3000/api/v1/children \\
+  -H "Authorization: Bearer $TOKEN"
+```

--- a/migrations/006_make_password_hash_nullable.sql
+++ b/migrations/006_make_password_hash_nullable.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+  ALTER COLUMN password_hash DROP NOT NULL;

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "dev": "node --env-file=.env.local node_modules/.bin/ts-node-dev --respawn --transpile-only src/index.ts",
+    "dev": "node --env-file-if-exists=.env.local node_modules/.bin/ts-node-dev --respawn --transpile-only src/index.ts",
     "build": "tsc -p tsconfig.json",
-    "start": "node --env-file=.env.local dist/index.js",
+    "start": "node --env-file-if-exists=.env.local dist/index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
+    "dev": "node --env-file=.env.local node_modules/.bin/ts-node-dev --respawn --transpile-only src/index.ts",
     "build": "tsc -p tsconfig.json",
-    "start": "node dist/index.js",
+    "start": "node --env-file=.env.local dist/index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],


### PR DESCRIPTION
Google / GitHub の OAuth ログインを追加し、認証後に JWT を発行してフロントへリダイレクトするフローを実装しました。
従来の email/password の signup/login も維持しています。