### PR TITLE
feat: Google Cloud Run 移行対応（C-1）

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.env*
+.git
+*.md

--- a/.github/workflows/deploy_cloud_run.yml
+++ b/.github/workflows/deploy_cloud_run.yml
@@ -1,0 +1,51 @@
+name: Deploy to Cloud Run
+
+on:
+  push:
+    branches: [main]
+
+env:
+  PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+  REGION: us-central1
+  SERVICE: ts-memo-api
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Build and push Docker image
+        run: |
+          gcloud builds submit \
+            --tag "gcr.io/$PROJECT_ID/$SERVICE:$GITHUB_SHA" \
+            --project "$PROJECT_ID"
+
+      - name: Deploy to Cloud Run
+        run: |
+          gcloud run deploy "$SERVICE" \
+            --image "gcr.io/$PROJECT_ID/$SERVICE:$GITHUB_SHA" \
+            --region "$REGION" \
+            --platform managed \
+            --min-instances 0 \
+            --max-instances 3 \
+            --memory 512Mi \
+            --cpu 1 \
+            --timeout 30s \
+            --set-secrets "DATABASE_URL=DATABASE_URL:latest,JWT_SECRET=JWT_SECRET:latest" \
+            --set-env-vars "NODE_ENV=production" \
+            --allow-unauthenticated \
+            --project "$PROJECT_ID"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# ── ビルドステージ ──────────────────────────────────────────────────────────────
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# ── 実行ステージ ────────────────────────────────────────────────────────────────
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY package*.json ./
+RUN npm ci --omit=dev
+COPY --from=builder /app/dist ./dist
+EXPOSE 8080
+CMD ["node", "dist/index.js"]

--- a/src/index.ts
+++ b/src/index.ts
@@ -1750,6 +1750,10 @@ app.patch("/api/v1/tasks/:taskId", async (req, res) => {
   }
 });
 
+app.get("/api/v1/health", (_req, res) => {
+  res.status(200).json({ status: "ok" });
+});
+
 const port = Number(process.env.PORT) || 3000;
 app.listen(port, () => {
   console.log(`API server running: http://localhost:${port}`);


### PR DESCRIPTION
- Dockerfile を追加（マルチステージビルド）
- .dockerignore を追加
- GitHub Actions デプロイワークフローを追加（main push → Cloud Run）
- GET /api/v1/health ヘルスチェックエンドポイントを追加